### PR TITLE
Adding missing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ modules: {
     label: 'Stories',
     instance: 'story',
     instanceLabel: 'Story',
+    menuName: 'aposStoryMenu',
     addFields: [
       {
         name: 'year',
@@ -149,7 +150,7 @@ The `instance` property is a singular word for one item - one story, in this cas
 
 **You must also create `lib/modules/stories` in your project.** Soon we'll add custom templates there, but it must exist even before you do that.
 
-**Edit `outerLayout.html`** and add a line to insert the menu for managing stories:
+**Edit `outerLayout.html`** and add a the same line you declared in the `stories.menuName` property above, to insert the menu for managing stories:
 
 ```jinja2
   {{ aposStoryMenu({ edit: permissions.admin }) }}


### PR DESCRIPTION
So I followed the directions for creating a new content type and was successful, however I had the unexpected result of having the type I was sub-classing / extending (in this case `apostrophe-blog`) overridden in the admin menu bar.  I was extending it but had trouble with adding it's menu in `outerLayout.html` and added `{{ aposCaseMenu(permissions) }}` but node was complaining `unable to call aposCaseMenu which is undefined of falsy`.  Poking around I found that `/node_modules/apostrophe-blog/` has a file called `index.js` where a property called `menuName` was defined which was the missing link.  
