### PR TITLE
add afterHandleHeadings and afterHandleHeadings

### DIFF
--- a/index.js
+++ b/index.js
@@ -931,7 +931,6 @@ snippets.Snippets = function(options, callback) {
             },
             function(data, callback) {
               return self.importCreateItem(req, data, function(err, item) {
-                console.log('created!', JSON.stringify(item, null, 100));
                 if (err) {
                   score.errors++;
                   score.errorLog.push((item.title || 'NO NAME') + ': ' + (err.message ? err.message : err));


### PR DESCRIPTION
This allows us to intervene with the way the CSV is being read for each snippet (in our case we needed to add items to an array on the snippet, which isn't supported by default)
